### PR TITLE
MANTA-5226: pgstatsmon probes time out on buckets deployment

### DIFF
--- a/sapi_manifests/pgstatsmon/template
+++ b/sapi_manifests/pgstatsmon/template
@@ -1,7 +1,7 @@
 {
     "interval": {{SCRAPE_INTERVAL}},
     "connections": {
-        "query_timeout": 1000,
+        "query_timeout": {{QUERY_TIMEOUT}},
         "connect_timeout": 3000,
         "connect_retries": 3
     },


### PR DESCRIPTION
Make `query_timeout` a SAPI configurable instead of hard-coding the value to 1000 ms / 1s.

Testing notes are in the ticket.